### PR TITLE
Fix panic when detected SDK does not have a bin directory

### DIFF
--- a/lib.rs
+++ b/lib.rs
@@ -539,8 +539,8 @@ fn get_sdk() -> io::Result<Vec<PathBuf>> {
                 kits.push(rc.parent().unwrap().to_owned());
             }
 
-            for ent in p.join("bin").read_dir().unwrap() {
-                if let Ok(e) = ent {
+            if let Ok(bin) = p.join("bin").read_dir() {
+                for e in bin.filter_map(|e| e.ok())  {
                     let p = if cfg!(target_arch = "x86_64") {
                         e.path().join(r"x64\rc.exe")
                     } else {


### PR DESCRIPTION
Due to old versions of Visual Studio having been installed in the past, my computer has an instance of the Windows 8.1 SDK detected as such:

    KitsRoot81    REG_SZ    C:\Program Files (x86)\Windows Kits\8.1\

Maybe because of a failed uninstallation or some other unknown reason, this directory does not contain a `bin` subdirectory, so `p.join("bin").read_dir().unwrap()` panics and causes the project's build to fail.

This PR fixes this panic by removing the call to `unwrap()` and reworks the loop logic to only iterate through entries that don't yield an error.

There are a few other uses of `unwrap` that could potentially cause problems, so I'm probably going to send some more PR's to refactor those.