### PR TITLE
Provide fallback implementation of compile_with_toolkit

### DIFF
--- a/lib.rs
+++ b/lib.rs
@@ -505,6 +505,11 @@ impl WindowsResource {
         println!("cargo:rustc-link-lib=dylib={}", "resource");
         Ok(())
     }
+
+    #[cfg(not(any(target_env = "gnu", target_env = "msvc")))]
+    fn compile_with_toolkit<'a>(&self, _input: &'a str, _output_dir: &'a str) -> io::Result<()> {
+        Err(io::Error::new(io::ErrorKind::Other, "Can only compile resource file when target_env is \"gnu\" or \"msvc\""))
+    }
 }
 
 /// Find a Windows SDK


### PR DESCRIPTION
This allows winres to still compile on non-gnu, non-msvc target_envs
(such as MacOS), although calls to compile_with_toolkit will always
fail in those cases.  This makes it simpler to depend on winres in
build scripts that target multiple platforms besides Windows.