### PR TITLE
Do not escape chars as unicode

### DIFF
--- a/lib.rs
+++ b/lib.rs
@@ -637,11 +637,15 @@ fn escape_string(string: &str) -> String {
         // In quoted RC strings, double-quotes are escaped by using two
         // consecutive double-quotes.  Other characters are escaped in the
         // usual C way using backslashes.
-        if chr == '"' {
-            escaped.push_str("\"\"");
-        } else {
-            escaped.extend(chr.escape_default());
-        }
+        match chr {
+            '"' => escaped.push_str("\"\""),
+            '\'' => escaped.push_str("\\'"),
+            '\\' => escaped.push_str("\\\\"),
+            '\n' => escaped.push_str("\\n"),
+            '\t' => escaped.push_str("\\t"),
+            '\r' => escaped.push_str("\\r"),
+            _ => escaped.push(chr),
+        };
     }
     escaped
 }


### PR DESCRIPTION
This PR changes the `escape_string` function to not escape higher characters. Previously, a copyright symbol `©` would be written as `\u{a9}` in the rc file, which the compiler didn't understand as escape sequence. With these changes, characters above 0x7e will not be escaped as unicode but instead written to the rc file as-is.