### PR TITLE
fix/windows-sdk-not-found

### DIFF
--- a/lib.rs
+++ b/lib.rs
@@ -592,6 +592,13 @@ fn get_sdk() -> io::Result<Vec<PathBuf>> {
             }
         }
     }
+    if kits.is_empty() {
+        return Err(io::Error::new(
+            io::ErrorKind::Other,
+            "Can not find Windows SDK",
+        ));
+    }
+
     Ok(kits)
 }
 

--- a/lib.rs
+++ b/lib.rs
@@ -370,7 +370,7 @@ impl WindowsResource {
 
     /// Write a resource file with the set values
     pub fn write_resource_file<P: AsRef<Path>>(&self, path: P) -> io::Result<()> {
-        let mut f = try!(fs::File::create(path));
+        let mut f = fs::File::create(path)?;
         // we don't need to include this, we use constants instead of macro names
         // try!(write!(f, "#include <winver.h>\n"));
 
@@ -554,7 +554,7 @@ fn get_sdk() -> io::Result<Vec<PathBuf>> {
         .output()?;
 
     let lines = String::from_utf8(output.stdout)
-        .or_else(|e| Err(io::Error::new(io::ErrorKind::Other, e.description())))?;
+        .or_else(|e| Err(io::Error::new(io::ErrorKind::Other, e.to_string())))?;
     let mut kits: Vec<PathBuf> = Vec::new();
     let mut lines: Vec<&str> = lines.lines().collect();
     lines.reverse();

--- a/lib.rs
+++ b/lib.rs
@@ -552,6 +552,17 @@ fn get_sdk() -> io::Result<Vec<PathBuf>> {
         .arg("/reg:32")
         .output()?;
 
+    if !output.status.success() {
+        return Err(io::Error::new(
+            io::ErrorKind::Other,
+            format!(
+                "Querying the registry failed with error message:\n{}",
+                String::from_utf8(output.stderr)
+                    .or_else(|e| Err(io::Error::new(io::ErrorKind::Other, e.to_string())))?
+            ),
+        ));
+    }
+
     let lines = String::from_utf8(output.stdout)
         .or_else(|e| Err(io::Error::new(io::ErrorKind::Other, e.to_string())))?;
     let mut kits: Vec<PathBuf> = Vec::new();

--- a/lib.rs
+++ b/lib.rs
@@ -52,7 +52,6 @@ use std::collections::HashMap;
 use std::io;
 use std::io::prelude::*;
 use std::fs;
-use std::error::Error;
 
 extern crate toml;
 


### PR DESCRIPTION
Do not return an Ok() value from get_sdk() in cases where we actually didn't find a SDK.

This PR handles the following error scenarios:
- Querying the registry failed, e.g. because the group policy forbids usage of the reg command for non-admin users
- Safety net before returning - check if kits contains at least one SDK path before returning it with an Ok() Result