### PR TITLE
Changed the default icon ID to `32512` to be in line with the Windows default.

### DIFF
--- a/lib.rs
+++ b/lib.rs
@@ -329,14 +329,18 @@ impl WindowsResource {
         self
     }
 
-    /// Add an icon with nameID `1`.
+    /// Add an icon with nameID `32512`.
     ///
-    /// This icon need to be in `ico` format. The filename can be absolute
+    /// This icon needs to be in `ico` format. The filename can be absolute
     /// or relative to the projects root.
     ///
-    /// Equivalent to `set_icon_with_id(path, "1")`.
+    /// Equivalent to `set_icon_with_id(path, "32512")`.
+    ///
+    /// Windows uses `32512` as the default icon ID. See
+    /// [here](https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-loadicona)
+    /// for Windows docs demonstrating this.
     pub fn set_icon<'a>(&mut self, path: &'a str) -> &mut Self {
-        self.set_icon_with_id(path, "1")
+        self.set_icon_with_id(path, "32512")
     }
 
     /// Add an icon with the specified name ID.


### PR DESCRIPTION
Fixes mxre/winres#28.

I think it's absolutely reasonable to change the default to match what Windows expects as the default. Users of this crate will expect `winres` to be a canonical source of information, and using a default value of `1` just because other exes weren't using the Windows default doesn't make sense to me.

I also found a Windows property called `DefaultIconResourceId`, and it's also set to `32512`: https://docs.microsoft.com/en-us/previous-versions/windows/desktop/cc982301(v=vs.85)