### PR TITLE
Fix #40 by using different linking flags depending on rustc version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ path = "lib.rs"
 
 [dependencies]
 toml = "0.5"
+version_check = "0.9.4"
 
 [dev-dependencies]
 # used for tests

--- a/lib.rs
+++ b/lib.rs
@@ -609,7 +609,12 @@ impl WindowsResource {
         }
 
         println!("cargo:rustc-link-search=native={}", output_dir);
-        println!("cargo:rustc-link-lib=static=resource");
+
+        if version_check::is_min_version("1.61.0").unwrap_or(true) {
+            println!("cargo:rustc-link-lib=static:+whole-archive=resource");
+        } else {
+            println!("cargo:rustc-link-lib=static=resource");
+        }
 
         Ok(())
     }


### PR DESCRIPTION
As suggested in the issue by petrochenkov.