### PR TITLE
Fixed wrong initialize for `FileDescription` in `new` function

### DIFF
--- a/lib.rs
+++ b/lib.rs
@@ -162,7 +162,7 @@ impl WindowsResource {
             env::var("CARGO_PKG_NAME").unwrap(),
         );
         match env::var("CARGO_PKG_DESCRIPTION") {
-            Ok(var) => props.insert("FileDescription".to_string(), var),
+            Ok(var) => { props.insert("FileDescription".to_string(), var) },
             Err(_) => (),
         };
 

--- a/lib.rs
+++ b/lib.rs
@@ -161,10 +161,10 @@ impl WindowsResource {
             "ProductName".to_string(),
             env::var("CARGO_PKG_NAME").unwrap(),
         );
-        props.insert(
-            "FileDescription".to_string(),
-            env::var("CARGO_PKG_NAME").unwrap(),
-        );
+        match env::var("CARGO_PKG_DESCRIPTION") {
+            Ok(var) => props.insert("FileDescription".to_string(), var),
+            Err(_) => (),
+        };
 
         parse_cargo_toml(&mut props).unwrap();
 

--- a/lib.rs
+++ b/lib.rs
@@ -162,7 +162,7 @@ impl WindowsResource {
             env::var("CARGO_PKG_NAME").unwrap(),
         );
         match env::var("CARGO_PKG_DESCRIPTION") {
-            Ok(var) => { props.insert("FileDescription".to_string(), var) },
+            Ok(var) => drop(props.insert("FileDescription".to_string(), var)),
             Err(_) => (),
         };
 


### PR DESCRIPTION
previously it was setting `CARGO_PKG_NAME` for `FileDescription` now I changed it to the right one (`CARGO_PKG_DESCRIPTION`)

also one thing that I'm not very  sure of is why you using `unwrap` everywhere... wasn't it better to match them? (I wanted to change them but I wasn't sure if its what you want)